### PR TITLE
Run deployments on repository dispatch

### DIFF
--- a/.github/workflows/hook-deploy-composite.yaml
+++ b/.github/workflows/hook-deploy-composite.yaml
@@ -1,12 +1,9 @@
-name: Deploy static content to composite target
-run-name: Deploy ${{ github.ref_name }} to composite target
+name: Deploy branch gh-pages to composite target
+run-name: Deploy branch gh-pages to composite target
 
 on:
-  # Runs on pushes targeting the GitHub pages branch
-  push:
-    branches: ["gh-pages"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  repository_dispatch:
+    types: [deployment-pushed]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Fixes the ongoing bug where deployments weren't taking place automatically.

Note that the corresponding dispatch has been added on the gh-pages branch; see https://github.com/CIROH-UA/training-NGIAB-101/blob/gh-pages/.github/workflows/hook-send-dispatch.yml.